### PR TITLE
Fix OPENCL_HEADERS for unified ones

### DIFF
--- a/02-buildsystem/repos/HeadersFinalize.cmake
+++ b/02-buildsystem/repos/HeadersFinalize.cmake
@@ -14,20 +14,14 @@
 
 include(${BUILDSYSTEM_BASE}/cmake/Common.cmake)
 
-set(KHR_OCL_VERSIONS 1.0 1.1 1.2 2.0 2.1 2.2)
+get_filename_component(KHRONOS_SDK_SRC
+  ${DLOADS_BASE}/opencl_headers/src/OPENCL_HEADERS REALPATH)
 
-foreach(V ${KHR_OCL_VERSIONS})
-  string(REPLACE "." "" VNODOT ${V})
-  get_filename_component(KHRONOS_SDK_SRC
-    ${DLOADS_BASE}/opencl_headers/src/OPENCL_HEADERS/opencl${VNODOT} REALPATH)
+get_filename_component(KHRONOS_SDK_DST
+  ${CL_REFHEADERS_BASE} REALPATH)
 
-  get_filename_component(KHRONOS_SDK_DST
-    ${CL_REFHEADERS_BASE}/opencl-${V} REALPATH)
+message("Cleaning old Khronos reference OpenCL headers")
+file(REMOVE ${KHRONOS_SDK_DST})
 
-  message("Cleaning old Khronos reference OpenCL ${V} headers")
-  file(REMOVE ${KHRONOS_SDK_DST})
-
-  message("Installing Khronos Reference OpenCL ${V} Headers")
-  file(INSTALL ${KHRONOS_SDK_SRC}/ DESTINATION ${KHRONOS_SDK_DST})
-
-endforeach(V)
+message("Installing Khronos Reference OpenCL Headers")
+file(INSTALL ${KHRONOS_SDK_SRC}/ DESTINATION ${KHRONOS_SDK_DST})


### PR DESCRIPTION
Other fixes I'm not sure of the best way to include are:
* https://github.com/KhronosGroup/SPIRV-LLVM/commit/81361659c523e6cef9cd66046334fe46619b9c00#diff-6daed8fde4789051cc55875ce87080b4 - is there any reason llvm 3.6.1 is still default?
* https://github.com/KhronosGroup/OpenCL-CTS/pull/3 - just waiting for the gods to merge this should be enough.. but shouldn't [some of this](https://github.com/KhronosGroup/OpenCL-CTS-Framework/blob/master/03-conformance-checks/cmake/CompilerChecks.cmake#L171) already be supposed to take care of that?